### PR TITLE
Add Expo Go support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the Expo app
+EXPO_PUBLIC_FILES_COM_API_KEY=
+EXPO_PUBLIC_FILES_COM_UPLOAD_URL=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# DeepSynth Expo App
+
+This project is an Expo application built with TypeScript and `expo-router`.
+
+## Requirements
+
+- Node.js 18+
+- Expo CLI (`npm install -g expo`)
+- An Expo account to sign in on your device
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the environment example and fill in your API values:
+   ```bash
+   cp .env.example .env
+   # Edit .env to include your Files.com API key and upload URL
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+4. Open the Expo Go app on your physical device and scan the QR code from the terminal or browser window.
+
+This will load the application in Expo Go for testing.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "**/*.ts",
     "**/*.tsx",
     ".expo/types/**/*.ts",
-    "expo-env.d.ts",
-    "nativewind-env.d.ts"
+    "expo-env.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- create README with Expo Go instructions
- add Expo babel config
- clean up tsconfig
- add environment example file

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*